### PR TITLE
void-mklive: Fixes for systems with md / lvm2

### DIFF
--- a/build-x86-images.sh.in
+++ b/build-x86-images.sh.in
@@ -24,27 +24,27 @@ readonly CINNAMON_PKGS="$X_PKGS lxdm cinnamon colord gnome-terminal gvfs-afc gvf
 
 [ ! -x mklive.sh ] && exit 0
 
-if [ -z "$TARGET" -o $TARGET = base ]; then
+if [ -z "$TARGET" -o "$TARGET" = base ]; then
 	if [ ! -e $BASE_IMG ]; then
 		./mklive.sh -o $BASE_IMG -p "$BASE_PKGS" $@
 	fi
 fi
-if [ -z "$TARGET" -o $TARGET = e ]; then
+if [ -z "$TARGET" -o "$TARGET" = e ]; then
 	if [ ! -e $E_IMG ]; then
 		./mklive.sh -o $E_IMG -p "$E_PKGS" $@
 	fi
 fi
-if [ -z "$TARGET" -o $TARGET = xfce ]; then
+if [ -z "$TARGET" -o "$TARGET" = xfce ]; then
 	if [ ! -e $XFCE_IMG ]; then
 		./mklive.sh -o $XFCE_IMG -p "$XFCE_PKGS" $@
 	fi
 fi
-if [ -z "$TARGET" -o $TARGET = mate ]; then
+if [ -z "$TARGET" -o "$TARGET" = mate ]; then
 	if [ ! -e $MATE_IMG ]; then
 		./mklive.sh -o $MATE_IMG -p "$MATE_PKGS" $@
 	fi
 fi
-if [ -z "$TARGET" -o $TARGET = cinnamon ]; then
+if [ -z "$TARGET" -o "$TARGET" = cinnamon ]; then
 	if [ ! -e $CINNAMON_IMG ]; then
 		./mklive.sh -o $CINNAMON_IMG -p "$CINNAMON_PKGS" $@
 	fi

--- a/installer.sh.in
+++ b/installer.sh.in
@@ -163,24 +163,25 @@ show_partitions() {
                 echo "size:${fssize:-unknown};fstype:${fstype:-none}"
             fi
         done
-        # Software raid (md)
-        for p in $(ls -d /dev/md* 2>/dev/null|grep '[0-9]'); do
-            if cat /proc/mdstat|grep -qw $(echo $p|sed -e 's|/dev/||g'); then
-                fstype=$(lsblk -nfr /dev/$part|awk '{print $2}')
-                fssize=$(lsblk -nr /dev/$p|awk '{print $4}')
-                echo "$p"
-                echo "size:${fssize:-unknown};fstype:${fstype:-none}"
-            fi
-        done
-        if [ ! -e /sbin/lvs ]; then
-            continue
+    done
+    # Software raid (md)
+    for p in $(ls -d /dev/md* 2>/dev/null|grep '[0-9]'); do
+        if cat /proc/mdstat|grep -qw $(echo $p|sed -e 's|/dev/||g'); then
+            fstype=$(lsblk -nfr /dev/$p|awk '{print $2}')
+            [ "$fstype" = "crypto_LUKS" ] && continue
+            [ "$fstype" = "LVM2_member" ] && continue
+            fssize=$(lsblk -nr /dev/$p|awk '{print $4}')
+            echo "$p"
+            echo "size:${fssize:-unknown};fstype:${fstype:-none}"
         fi
+    done
+    if [ -e /sbin/lvs ]; then
         # LVM
         lvs --noheadings|while read lvname vgname perms size; do
             echo "/dev/mapper/${vgname}-${lvname}"
             echo "size:${size};fstype:lvm"
         done
-    done
+    fi
 }
 
 menu_filesystems() {


### PR DESCRIPTION
- Add quotes around $TARGET to allow for empty $1 in build-x86-images.sh
- In installer.sh there was $part for md where it should have been $p
- The list of md and lvm partitions should occur just once, thus move it out of the loop