### PR TITLE
installer.sh.in: really fix the md parsing

### DIFF
--- a/build-arm-images.sh.in
+++ b/build-arm-images.sh.in
@@ -4,7 +4,7 @@ TARGET="$1"
 
 set -e
 
-PLATFORMS="beaglebone cubieboard2 odroid-u2 rpi rpi2 usbarmory"
+PLATFORMS="beaglebone cubieboard2 cubietruck odroid-u2 rpi rpi2 usbarmory"
 DATE=$(date '+%Y%m%d')
 
 for f in ${PLATFORMS}; do

--- a/build-rootfs.sh.in
+++ b/build-rootfs.sh.in
@@ -4,7 +4,7 @@ set -e
 
 TARGET="$1"
 
-PLATFORMS="beaglebone cubieboard2 odroid-u2 rpi rpi2 usbarmory"
+PLATFORMS="beaglebone cubieboard2 cubietruck odroid-u2 rpi rpi2 usbarmory"
 
 for f in ${PLATFORMS}; do
 	if [ -z "$TARGET" -o "$TARGET" = "$f" ]; then

--- a/installer.sh.in
+++ b/installer.sh.in
@@ -166,11 +166,12 @@ show_partitions() {
     done
     # Software raid (md)
     for p in $(ls -d /dev/md* 2>/dev/null|grep '[0-9]'); do
-        if cat /proc/mdstat|grep -qw $(echo $p|sed -e 's|/dev/||g'); then
-            fstype=$(lsblk -nfr /dev/$p|awk '{print $2}')
+        part=$(basename $p)
+        if cat /proc/mdstat|grep -qw $part; then
+            fstype=$(lsblk -nfr /dev/$part|awk '{print $2}')
             [ "$fstype" = "crypto_LUKS" ] && continue
             [ "$fstype" = "LVM2_member" ] && continue
-            fssize=$(lsblk -nr /dev/$p|awk '{print $4}')
+            fssize=$(lsblk -nr /dev/$part|awk '{print $4}')
             echo "$p"
             echo "size:${fssize:-unknown};fstype:${fstype:-none}"
         fi

--- a/mkimage.sh.in
+++ b/mkimage.sh.in
@@ -113,7 +113,7 @@ fi
 
 # double check PLATFORM is supported...
 case "$PLATFORM" in
-    bananapi|beaglebone|cubieboard2|odroid-u2|rpi|rpi2|usbarmory);;
+    bananapi|beaglebone|cubieboard2|cubietruck|odroid-u2|rpi|rpi2|usbarmory);;
     *) die "The $PLATFORM is not supported, exiting..."
 esac
 
@@ -175,16 +175,20 @@ fi
 echo "UUID=$ROOT_UUID / $ROOT_FSTYPE defaults 0 ${fspassno}" >> ${ROOTFSDIR}/etc/fstab
 echo "UUID=$BOOT_UUID /boot $BOOT_FSTYPE defaults${fstab_args} 0 2" >> ${ROOTFSDIR}/etc/fstab
 
-if [ "$PLATFORM" = "cubieboard2" -o "$PLATFORM" = "bananapi" ]; then
+case "$PLATFORM" in
+bananapi|cubieboard2|cubietruck)
     dd if=${ROOTFSDIR}/boot/u-boot-sunxi-with-spl.bin of=${LOOPDEV} bs=1024 seek=8 >/dev/null 2>&1
-elif [ "$PLATFORM" = "odroid-u2" ]; then
+    ;;
+odroid-u2)
     dd if=${ROOTFSDIR}/boot/E4412_S.bl1.HardKernel.bin of=${LOOPDEV} seek=1 >/dev/null 2>&1
     dd if=${ROOTFSDIR}/boot/bl2.signed.bin of=${LOOPDEV} seek=31 >/dev/null 2>&1
     dd if=${ROOTFSDIR}/boot/u-boot.bin of=${LOOPDEV} seek=63 >/dev/null 2>&1
     dd if=${ROOTFSDIR}/boot/E4412_S.tzsw.signed.bin of=${LOOPDEV} seek=2111 >/dev/null 2>&1
-elif [ "$PLATFORM" = "usbarmory" ]; then
+    ;;
+usbarmory)
     dd if=${ROOTFSDIR}/boot/u-boot.imx of=${LOOPDEV} bs=512 seek=2 conv=fsync
-fi
+    ;;
+esac
 
 mountpoint -q ${ROOTFSDIR}/boot && umount ${ROOTFSDIR}/boot
 umount $ROOTFSDIR


### PR DESCRIPTION
The previous fix was buggy in that it used `$p = /dev/mdX` with `/dev` prepended again. Like for disks, now `part=$(basename $p)`