### PR TITLE
mkimage.sh: fix partition size + toggle boot flag

### DIFF
--- a/mkimage.sh.in
+++ b/mkimage.sh.in
@@ -143,7 +143,8 @@ if [ "$BOOT_FSTYPE" = "vfat" ]; then
 fi
 case "$PLATFORM" in
 cubieboard2|cubietruck)
-    parted $FILENAME mkpart primary ext2 2048s ${BOOT_FSSIZE} 100%
+    parted $FILENAME mkpart primary ext2 2048s ${ROOT_FSSIZE} 100%
+    parted $FILENAME toggle 1 boot
     LOOPDEV=$(losetup --show --find --partscan $FILENAME)
     mkfs.${ROOT_FSTYPE} $disable_journal ${LOOPDEV}p1 >/dev/null 2>&1
     mount ${LOOPDEV}p1 $ROOTFSDIR


### PR DESCRIPTION
The BOOT_FSSIZE is just 64M and should not be used for cubieboard2|cubietruck.
Toggling the boot flag may not be required, set it just for consistency.