### PR TITLE
installer.sh: fix static IP settings in menu_install

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -913,7 +913,7 @@ ${BOLD}Do you want to continue?${RESET}" 20 80 || return
             else
                 enable_dhcpd
             fi
-        elif [ -n "$dev" -a -n "$type" = "static" ]; then
+        elif [ -n "$_dev" -a "$_type" = "static" ]; then
             # static IP through dhcpcd.
             mv $TARGETDIR/etc/dhcpcd.conf $TARGETDIR/etc/dhdpcd.conf.orig
             echo "# Static IP configuration set by the void-installer for $_dev." \


### PR DESCRIPTION
This is a fix for the first part of Donald Allen's post [here](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/voidlinux/WR2dLcmhojU).