### PR TITLE
fix set_keymap rc.conf

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -299,7 +299,7 @@ set_keymap() {
     if [ -f /etc/vconsole.conf ]; then
         sed -i -e "s|KEYMAP=.*|KEYMAP=$KEYMAP|g" $TARGETDIR/etc/vconsole.conf
     else
-        sed -i -e "s|KEYMAP=.*|KEYMAP=$KEYMAP|g" $TARGETDIR/etc/rc.conf
+        sed -i -e "s|#\?KEYMAP=.*|KEYMAP=$KEYMAP|g" $TARGETDIR/etc/rc.conf
     fi
 }
 


### PR DESCRIPTION
By default `/etc/rc.conf` seems to have `KEYMAP` commented out which means any key mapping set during the install will be ignored. This commit makes the installer remove the hash (`#`) prefix, if present.