### PR TITLE
Add Automatic install option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.img
 *.xz
 xbps-cachedir*
+!autoinstaller/opt/void-autoinstall/install.sh
+!autoinstaller/opt/void-autoinstall/chroot_install.sh

--- a/autoinstaller/etc/sv/agetty-tty1/conf
+++ b/autoinstaller/etc/sv/agetty-tty1/conf
@@ -1,0 +1,15 @@
+if [ -x /sbin/agetty -o /bin/agetty ]; then
+    if [ "${tty}" = "tty1" ]; then
+	grep -q auto /proc/cmdline
+	rc=$?
+	if [ $rc -eq 0 ] ; then
+	    GETTY_ARGS="--noclear --autologin root"
+	else
+	    # util-linux specific settings
+	    GETTY_ARGS="--noclear"
+	fi
+    fi
+fi
+
+BAUD_RATE=38400
+TERM_NAME=linux

--- a/autoinstaller/opt/void-autoinstall/chroot_install.sh
+++ b/autoinstaller/opt/void-autoinstall/chroot_install.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+
+set -e
+
+# These functions pulled from void's excellent mklive.sh
+info_msg() {
+    printf "\033[1min-target: $@\n\033[m"
+}
+die() {
+    info_msg "ERROR: $@"
+    exit 1
+}
+print_step() {
+    CURRENT_STEP=$((CURRENT_STEP+1))
+    info_msg "[${CURRENT_STEP}/${STEP_COUNT}] $@"
+}
+
+# ----------------------- Install Functions ------------------------
+
+correct_permission() {
+    # Fix permissions
+    chown root:root /
+    chmod 755 /
+}
+
+add_user() {
+    USERPASS=%PASSWORD%
+    useradd -m -s /bin/bash -U -G wheel,users,audio,video,cdrom,input %USERNAME%
+    if [ -z "${USERPASS}" ] ; then
+	passwd %USERNAME%
+    else
+	echo "%USERNAME%:${USERPASS}" | chpasswd -c SHA512
+    fi
+}
+
+grant_sudo() {
+    # Give wheel sudo
+    echo "%wheel ALL=(ALL) ALL" > /etc/sudoers.d/wheel
+}
+
+set_hostname() {
+    # Set the hostname
+    echo "%HOSTNAME%" > /etc/hostname
+}
+
+configure_rc_conf() {
+    # Fix the rc.conf file
+    ed -s /etc/rc.conf <<EOF
+,s_void-live_%HOSTNAME%_
+,s,Europe/Madrid,%TIMEZONE%,
+,s/"es"/"%KEYMAP%"
+/HOSTNAME/s/#//
+/HARDWARECLOCK/s/#//
+/TIMEZONE/s/#//
+/KEYMAP/s/#//
+w
+EOF
+}
+
+configure_fstab() {
+    # Grab UUIDS
+    uuid1=`blkid | grep '%DISK%1:' | awk -F '"' '{print $2}'`
+    uuid2=`blkid | grep '%DISK%2:' | awk -F '"' '{print $2}'`
+    uuid3=`blkid | grep '%DISK%3:' | awk -F '"' '{print $2}'`
+
+    # Fix the fstab file
+    ed -s /etc/fstab <<EOF
+/tmpfs/d
+a
+UUID=$uuid3 / ext4 defaults,errors=remount-ro 0 1
+UUID=$uuid1 /boot ext4 defaults 0 2
+UUID=$uuid2 swap swap defaults 0 0
+.
+w
+EOF
+}
+
+configure_locale() {
+    # Set the libc-locale iff glibc
+    case $(xbps-uhelper arch) in
+	*-musl)
+	    info_msg "Glibc locales are not supported on musl"
+	    ;;
+	*)
+	    ed -s /etc/default/libc-locales <<EOF
+/%LIBCLOCALE%/s/#//
+w
+EOF
+
+	    xbps-reconfigure -f glibc-locales
+	    ;;
+    esac
+}
+
+configure_grub() {
+    # Set hostonly
+    echo "hostonly=yes" > /etc/dracut.conf.d/hostonly.conf
+
+    # Choose the newest kernel
+    kernel_version=`ls /lib/modules | cut -f1,2 -d'.' | uniq | sort -Vr | sed -n 1p`
+
+    # Install grub
+    grub-install %DISK%
+    xbps-reconfigure -f "linux${kernel_version}"
+    passwd -l root
+}
+
+# -------------- chroot "main()" ---------------------------
+CURRENT_STEP=0
+STEP_COUNT=8
+
+print_step "Correcting permissions on /"
+correct_permission
+
+print_step "Adding initial user %USERNAME%"
+add_user
+
+print_step "Granting sudo to initial user: %USERNAME%"
+grant_sudo
+
+print_step "Setting hostname to %HOSTNAME%"
+set_hostname
+
+print_step "Configuring /etc/rc.conf"
+configure_rc_conf
+
+print_step "Configuring mounts in /etc/fstab"
+configure_fstab
+
+print_step "Configuring glibc-locale"
+configure_locale
+
+print_step "Configuring and installing grub"
+configure_grub

--- a/autoinstaller/opt/void-autoinstall/config.cfg
+++ b/autoinstaller/opt/void-autoinstall/config.cfg
@@ -1,0 +1,53 @@
+# Void Linux Automatic Install Configuration
+
+# ===
+# Disk Configuration
+# ===
+# disk: the disk to install to
+# default: the first disk that isn't the installer
+#disk=/dev/hda
+
+# bootpartitionsize: controls how large the boot partition will be
+# default: 500M
+#bootpartitionsize=500M
+
+# swapsize: how large should the swap partition be
+# default: equal to the installed physical memory
+#swapsize=""
+
+# ===
+# XBPS Configuration
+# ===
+# xbpsrepository: which repo should the install pull from
+# default: http://repo.voidlinux.eu/current
+#xbpsrepository=http://repo.voidlinux.eu/current
+
+# pkgs: additional packages to install into the target
+# default: none
+#pkgs=""
+
+# ===
+# Default User
+# ===
+# username: the username of the user to be created
+# default: voidlinux
+#username=""
+
+# password: password to set for the new user
+# default: unset (will prompt during install)
+#password=""
+
+# ===
+# Misc. Options
+# ===
+# timezone: Timezone in TZ format
+# default: America/Chicago
+#timezone="America/Chicago"
+
+# keymap: Keymap to use by default
+# default: us
+#keymap
+
+# locale: initial glibc locale
+# default: en_US.UTF-8
+#libclocale=en.US.UTF-8

--- a/autoinstaller/opt/void-autoinstall/install.sh
+++ b/autoinstaller/opt/void-autoinstall/install.sh
@@ -1,0 +1,200 @@
+#!/bin/sh
+
+set -e
+
+# These functions pulled from void's excellent mklive.sh
+info_msg() {
+    printf "\033[1m$@\n\033[m"
+}
+die() {
+    info_msg "ERROR: $@"
+    exit 1
+}
+print_step() {
+    CURRENT_STEP=$((CURRENT_STEP+1))
+    info_msg "[${CURRENT_STEP}/${STEP_COUNT}] $@"
+}
+
+# ----------------------- Install Functions ------------------------
+
+welcome() {
+    clear
+    printf "=============================================================\n"
+    printf "================ Void Linux Auto-Installer ==================\n"
+    printf "=============================================================\n"
+}
+
+get_address() {
+    # Get an IP address
+    dhcpcd -w
+    sleep 15
+}
+
+partition_disk() {
+    # Paritition Disk
+    sfdisk $disk <<EOF
+,$bootpartitionsize
+,$swapsize
+;
+EOF
+}
+
+format_disk() {
+    # Make Filesystems
+    mkfs.ext4 -F "${disk}1"
+    mkfs.ext4 -F "${disk}3"
+    mkswap -f "${disk}2"
+}
+
+mount_target() {
+    # Mount targetfs
+    mount "${disk}3" $mountpoint
+    mkdir "${mountpoint}/boot"
+    mount "${disk}1" "${mountpoint}/boot"
+}
+
+install_xbps_keys() {
+    mkdir -p ${mountpoint}/var/db/xbps/keys
+    cp /var/db/xbps/keys/* ${mountpoint}/var/db/xbps/keys
+}
+install_base_system() {
+    # Install a base system
+    XBPS_ARCH=$XBPS_ARCH xbps-install -Sy -R $xbpsrepository -r /mnt base-system grub ed $pkgs
+}
+
+template_chroot_script() {
+    # Write the *real* install script
+    xbps-install -Sy bind-utils ed
+    ip_address=`ip a | grep 'inet' | grep -v ' lo' | awk '{print $2}' | sed 's/\/.*$//'`
+    hostname=`dig +short -x $ip_address | sed 's/\..*$//'`
+    [ -z "$hostname" ] && hostname="void-computer"
+    ed -s ./chroot_install.sh <<EOF
+,s_%HOSTNAME%_${hostname}_g
+,s,%DISK%,$disk,g
+,s,%TIMEZONE%,$timezone,g
+,s/%KEYMAP%/$keymap/g
+,s/%LIBCLOCALE%/$libclocale/g
+,s/%USERNAME%/$username/g
+,s/%PASSWORD%/$password/g
+w
+EOF
+}
+
+install_chroot_script() {
+    # Copy file and make sure it is executable
+    cp ./chroot_install.sh $mountpoint
+    chmod +x "${mountpoint}/chroot_install.sh"
+}
+
+prepare_chroot() {
+    # Mount dev, bind, proc, etc into chroot
+    mount -t proc proc "${mountpoint}/proc"
+    mount -t sysfs sys "${mountpoint}/sys"
+    mount -o rbind /dev "${mountpoint}/dev"
+}
+
+run_chroot_script() {
+    # Run the install tasks
+    cd $mountpoint
+    chroot $mountpoint "./chroot_install.sh"
+    rm ${mountpoint}/chroot_install.sh
+}
+
+
+configure_autoinstall() {
+    # this has to happen after the network since we might need curl
+
+    # -------------------------- Setup defaults ---------------------------
+    bootpartitionsize="500M"
+    disk=`lsblk -ipo NAME,TYPE,MOUNTPOINT | awk '{if ($2=="disk") {disks[$1]=0; last=$1} if ($3=="/") {disks[last]++}} END {for (a in disks) {if(disks[a] == 0){print a; break}}}'`
+    swapsize="`grep MemTotal /proc/meminfo | awk '{print $2}'`K";
+    mountpoint="/mnt"
+    timezone="America/Chicago"
+    keymap="us"
+    libclocale="en_US.UTF-8"
+    username="voidlinux"
+
+    XBPS_ARCH=$(xbps-uhelper arch)
+    case $XBPS_ARCH in
+	*-musl)
+	    xbpsrepository="http://muslrepo.voidlinux.eu/current"
+	;;
+	*)
+	    xbpsrepository="http://repo.voidlinux.eu/current"
+	    ;;
+    esac
+
+    # --------------- Pull config URL out of kernel cmdline -------------------------
+    procurl=`awk '{for(i = 1; i <= NF; i++) { split($i,a,"="); if(a[1]=="autourl"){print a[2]} }}' /proc/cmdline`
+    if [ -z "$procurl" ]
+    then
+	info_msg "No config url found in /proc/cmdline."
+    else
+	xbps-uhelper fetch>config.cfg $procurl
+    fi
+
+    # ---------------- Parse command line args ----------------------------
+    while getopts "u:" opt; do
+	case $opt in
+	    u)
+		xbps-uhelper fetch>config.cfg $OPTARG
+		;;
+	    \?)
+		die "Invalid option: -$OPTARG" >&2
+		exit 1
+		;;
+	esac
+
+    done
+
+    # Read in the resulting config file which we got via some method
+    if [ -f ./config.cfg ] ; then
+	info_msg "Reading configuration file"
+	. ./config.cfg
+    fi
+
+    # Bail out if we didn't get a usable disk
+    if [ -z "$disk" ] ; then
+	die "No valid disk!"
+    fi
+}
+
+# ------------------- Install "main()" ----------------------------
+
+CURRENT_STEP=0
+STEP_COUNT=10
+
+welcome
+
+print_step "Bring up the network"
+get_address
+
+print_step "Configure installer"
+configure_autoinstall
+
+print_step "Configuring disk using scheme 'Atomic'"
+partition_disk
+format_disk
+
+print_step "Mounting the target filesystems"
+mount_target
+
+print_step "Install XBPS keys"
+install_xbps_keys
+
+print_step "Installing the base system"
+install_base_system
+
+print_step "Configuring chroot installer"
+template_chroot_script
+
+print_step "Installing chroot installer"
+install_chroot_script
+
+print_step "Prepare the chroot"
+prepare_chroot
+
+print_step "Executing chroot installer"
+run_chroot_script
+
+info_msg "Installation Complete!"

--- a/autoinstaller/root/.profile
+++ b/autoinstaller/root/.profile
@@ -1,0 +1,8 @@
+if [ "$(tty)" = "/dev/tty1" ] ; then
+    grep -q auto /proc/cmdline
+    rc=$?
+    if [ $rc -eq 0 ] ; then
+	cd /opt/void-autoinstall/
+	bash install.sh
+    fi
+fi

--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -354,7 +354,7 @@ ISOLINUX_DIR="$BOOT_DIR/isolinux"
 GRUB_DIR="$BOOT_DIR/grub"
 ISOLINUX_CFG="$ISOLINUX_DIR/isolinux.cfg"
 CURRENT_STEP=0
-STEP_COUNT=9
+STEP_COUNT=10
 [ -n "${INCLUDE_DIRECTORY}" ] && ((STEP_COUNT=STEP_COUNT+1))
 
 : ${SYSLINUX_DATADIR:=$VOIDHOSTDIR/usr/share/syslinux}
@@ -395,6 +395,10 @@ if [ -n "${INCLUDE_DIRECTORY}" ];then
     print_step "Copying directory structure into the rootfs: ${INCLUDE_DIRECTORY} ..."
     copy_include_directory
 fi
+
+print_step "Installing auto-installer..."
+INCLUDE_DIRECTORY=autoinstaller
+copy_include_directory
 
 print_step "Generating initramfs image ($INITRAMFS_COMPRESSION)..."
 generate_initramfs


### PR DESCRIPTION
This commit adds an autoinstaller to Void.
This installer was a joint venture between:
  - the-maldridge
  - dinoocch

The original work tree can be found here:
https://github.com/dinoocch/void_auto_installer

The installer has the current limitations:
  - ~~Works on glibc only (has not been tested on muslc).~~ Works on musl now
  - Supports a single "Atomic" partition layout, similar to Debian.
  - Does not support UEFI (very difficult to make it work across all vendors)

The installer may be invoked using one of 2 methods:
  - Passing the "auto" keyword on the kernel command line will use baked in config values
  - Passing the "autourl=<url>" key/value pair will obtain a config file from the stated source.

In both cases it is assumed you have a functional DHCP server with a functional internet connection to run the install.