### PR TITLE
mkimage.sh.in: add option to run custom scripts

### DIFF
--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -77,7 +77,8 @@ Options:
  -o <file>          Output file name for the ISO image (auto if unset).
  -p "pkg pkgN ..."  Install additional packages into the ISO image.
  -I <includedir>    Include directory structure under given path into rootfs
-
+ -H <hooksdir>      Add scripts in given directory as startup hooks to the init 
+                    procedure.
  -C "cmdline args"  Add additional kernel command line arguments.
  -T "title"         Modify the bootloader title.
  -K                 Do not remove builddir.
@@ -171,6 +172,13 @@ cleanup_rootfs() {
         fi
     done
     rm -r $ROOTFS/usr/lib/dracut/modules.d/01vmklive
+}
+
+setup_init_hooks() {
+    hooks_dir=/usr/local/custom-scripts/
+    mkdir -p ${ROOTFS}${hooks_dir}
+    find $HOOKS_DIRECTORY -mindepth 1 -maxdepth 1 -exec cp -rfpPv {} ${ROOTFS}${hooks_dir} \;
+    echo 'find '${hooks_dir}' -type f -executable -exec {} \;' >> $ROOTFS/etc/rc.local
 }
 
 generate_isolinux_boot() {
@@ -292,7 +300,7 @@ generate_iso_image() {
 #
 # main()
 #
-while getopts "a:b:r:c:C:T:Kk:l:i:I:s:S:o:p:h" opt; do
+while getopts "a:b:r:c:C:T:Kk:l:i:I:H:s:S:o:p:h" opt; do
     case $opt in
         a) BASE_ARCH="$OPTARG";;
         b) BASE_SYSTEM_PKG="$OPTARG";;
@@ -302,7 +310,8 @@ while getopts "a:b:r:c:C:T:Kk:l:i:I:s:S:o:p:h" opt; do
         k) KEYMAP="$OPTARG";;
         l) LOCALE="$OPTARG";;
         i) INITRAMFS_COMPRESSION="$OPTARG";;
-        I) INCLUDE_DIRECTORY="$OPTARG";;
+        I) INCLUDE_DIRECTORY=$(cd "$OPTARG" && pwd);;
+        H) HOOKS_DIRECTORY=$(cd "$OPTARG" && pwd);;
         s) SQUASHFS_COMPRESSION="$OPTARG";;
         S) ROOTFS_FREESIZE="$OPTARG";;
         o) OUTPUT_FILE="$OPTARG";;
@@ -355,7 +364,8 @@ GRUB_DIR="$BOOT_DIR/grub"
 ISOLINUX_CFG="$ISOLINUX_DIR/isolinux.cfg"
 CURRENT_STEP=0
 STEP_COUNT=9
-[ -n "${INCLUDE_DIRECTORY}" ] && ((STEP_COUNT=STEP_COUNT+1))
+[ -n "${INCLUDE_DIRECTORY}" ] && STEP_COUNT=$((STEP_COUNT+1))
+[ -n "${HOOKS_DIRECTORY}" ] && STEP_COUNT=$((STEP_COUNT+1))
 
 : ${SYSLINUX_DATADIR:=$VOIDHOSTDIR/usr/share/syslinux}
 : ${GRUB_DATADIR:=$VOIDHOSTDIR/usr/share/grub}
@@ -407,6 +417,9 @@ generate_grub_efi_boot
 
 print_step "Cleaning up rootfs..."
 cleanup_rootfs
+
+print_step "Creating startup hooks..."
+setup_init_hooks
 
 print_step "Generating squashfs image ($SQUASHFS_COMPRESSION) from rootfs..."
 generate_squashfs


### PR DESCRIPTION
I was looking for a way to change the default shell to bash, so I came up with this idea to run custom scripts as a post-rootfs-creation hook:

The added option -H <hooksdir> allows the user to specify a directory
that contains scripts which should be run after the creation of the
root filesystem to make modifications (such as e.g. setting the
default shell)
The scripts in the hooks dir can assume the rootfs directory of the
build to be the working directory.

Let me know what you think...
