### PR TITLE
installer.sh.in: fixes and improvements

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -93,6 +93,13 @@ DIALOG() {
     return $?
 }
 
+INFOBOX() {
+    # Note: dialog --infobox and --keep-tite don't work together
+    dialog --colors --no-shadow --no-mouse \
+        --backtitle "${BOLD}${WHITE}Void Linux installation -- http://www.voidlinux.eu/ (@@MKLIVE_VERSION@@)${RESET}" \
+        --title "${TITLE}" --aspect 20 --infobox "$@"
+}
+
 DIE() {
     rval=$1
     [ -z "$rval" ] && rval=0
@@ -517,13 +524,13 @@ menu_locale() {
     local _locales="$(grep -E '\.UTF-8' /etc/default/libc-locales|awk '{print $1}'|sed -e 's/^#//')"
     local LOCALES ISO639 ISO3166
     local TMPFILE=$(mktemp -t vinstall-XXXXXXXX || exit 1)
-
-    echo "Scanning locales..."
+    INFOBOX "Scanning locales ..." 4 60
     for f in ${_locales}; do
         eval $(echo $f | awk 'BEGIN { FS="." } \
             { FS="_"; split($1, a); printf "ISO639=%s ISO3166=%s\n", a[1], a[2] }')
         echo "$f|$(iso639_language $ISO639) ($(iso3166_country $ISO3166))|" >> $TMPFILE
     done
+    clear
     # Sort by ISO-639 language names
     LOCALES=$(sort -t '|' -k 2 < $TMPFILE | xargs | sed -e's/| /|/g')
     rm -f $TMPFILE
@@ -596,10 +603,10 @@ menu_rootpassword() {
     local _firstpass _secondpass _desc
 
     while true; do
-        if [ -n "${_firstpass}" ]; then
-            _desc="Enter the root password again"
-        else
+        if [ -z "${_firstpass}" ]; then
             _desc="Enter the root password"
+        else
+            _desc="$_desc again"
         fi
         DIALOG --insecure --passwordbox "${_desc}" ${INPUTSIZE}
         if [ $? -eq 0 ]; then
@@ -610,9 +617,9 @@ menu_rootpassword() {
             fi
             if [ -n "${_firstpass}" -a -n "${_secondpass}" ]; then
                 if [ "${_firstpass}" != "${_secondpass}" ]; then
-                    DIALOG --infobox "Passwords do not match! Please enter again." 6 80
+                    INFOBOX "Passwords do not match! Please enter again." 6 60
                     unset _firstpass _secondpass
-                    sleep 2 && continue
+                    sleep 2 && clear && continue
                 fi
                 set_option ROOTPASSWORD "${_firstpass}"
                 ROOTPASSWORD_DONE=1
@@ -631,9 +638,12 @@ set_rootpassword() {
 menu_useraccount() {
     local _firstpass _secondpass _desc
     local _groups _status _group _checklist
+    local _preset
 
     while true; do
-        DIALOG --inputbox "Enter a primary login name:" ${INPUTSIZE} "void"
+        _preset=$(get_option USERLOGIN)
+        [ -z "$_preset" ] && _preset="void"
+        DIALOG --inputbox "Enter a primary login name:" ${INPUTSIZE} "$_preset"
         if [ $? -eq 0 ]; then
             set_option USERLOGIN "$(cat $ANSWER)"
             USERLOGIN_DONE=1
@@ -644,8 +654,10 @@ menu_useraccount() {
     done
 
     while true; do
+        _preset=$(get_option USERNAME)
+        [ -z "$_preset" ] && _preset="Void User"
         DIALOG --inputbox "Enter a user name for login '$(get_option USERLOGIN)' :" \
-            ${INPUTSIZE} "$(get_option USERLOGIN)"
+            ${INPUTSIZE} "$_preset"
         if [ $? -eq 0 ]; then
             set_option USERNAME "$(cat $ANSWER)"
             USERNAME_DONE=1
@@ -656,10 +668,10 @@ menu_useraccount() {
     done
 
     while true; do
-        if [ -n "${_firstpass}" ]; then
-            _desc="Enter the password for login '$(get_option USERLOGIN)' again"
-        else
+        if [ -z "${_firstpass}" ]; then
             _desc="Enter the password for login '$(get_option USERLOGIN)'"
+        else
+            _desc="$_desc again"
         fi
         DIALOG --insecure --passwordbox "${_desc}" ${INPUTSIZE}
         if [ $? -eq 0 ]; then
@@ -670,9 +682,9 @@ menu_useraccount() {
             fi
             if [ -n "${_firstpass}" -a -n "${_secondpass}" ]; then
                 if [ "${_firstpass}" != "${_secondpass}" ]; then
-                    DIALOG --infobox "Passwords do not match! Please enter again." 6 80
+                    INFOBOX "Passwords do not match! Please enter again." 6 60
                     unset _firstpass _secondpass
-                    sleep 2 && continue
+                    sleep 2 && clear && continue
                 fi
                 set_option USERPASSWORD "${_firstpass}"
                 USERPASSWORD_DONE=1
@@ -1003,7 +1015,8 @@ failed to activate swap on $dev!\ncheck $LOG for errors." ${MSGBOXSIZE}
             vfat) MKFS="mkfs.vfat -F32"; modprobe vfat >$LOG 2>&1;;
             xfs) MKFS="mkfs.xfs -f"; modprobe xfs >$LOG 2>&1;;
             esac
-            DIALOG --infobox "Creating filesystem $fstype on $dev for $mntpt ..." 8 60
+            TITLE="Check $LOG for details ..."
+            INFOBOX "Creating filesystem $fstype on $dev for $mntpt ..." 8 60
             echo "Running $MKFS $dev..." >$LOG
             $MKFS $dev >$LOG 2>&1; rv=$?
             if [ $rv -ne 0 ]; then
@@ -1087,13 +1100,38 @@ umount_filesystems() {
     umount $TARGETDIR >$LOG 2>&1
 }
 
+log_and_count() {
+    local progress whole tenth
+    while read line; do
+        echo "$line" >$LOG
+        copy_count=$((copy_count + 1))
+        progress=$((1000 * copy_count / copy_total))
+        if [ "$progress" != "$copy_progress" ]; then
+            whole=$((progress / 10))
+            tenth=$((progress % 10))
+            printf "Progress: %d.%d%% (%d of %d files)\n" $whole $tenth $copy_count $copy_total
+            copy_progress=$progress
+        fi
+    done
+}
+
 copy_rootfs() {
-    DIALOG --title "Check $LOG for details" \
-        --infobox "Copying live image to target rootfs, please wait ..." 4 60
-    LANG=C cp -axvnu / $TARGETDIR >$LOG 2>&1
+    local tar_in="--create --one-file-system"
+    local tar_out="--extract --preserve-permissions"
+    TITLE="Check $LOG for details ..."
+    INFOBOX "Counting files, please be patient ..." 4 60
+    copy_total=$(tar ${tar_in} -v -f /dev/null / 2>/dev/null | wc -l)
+    export copy_total copy_count=0 copy_progress=
+    clear
+    tar ${tar_in} -f - / 2>/dev/null | \
+        tar ${tar_out} -v -f - -C $TARGETDIR | \
+        log_and_count | \
+        DIALOG --title "${TITLE}" \
+            --progressbox "Copying live image to target rootfs." 5 60
     if [ $? -ne 0 ]; then
         DIE 1
     fi
+    unset copy_total copy_count copy_percent
 }
 
 install_packages() {
@@ -1171,14 +1209,13 @@ ${BOLD}Do you want to continue?${RESET}" 20 80 || return
         echo "Removing $USERNAME live user from targetdir ..." >$LOG
         chroot $TARGETDIR userdel -r $USERNAME >$LOG 2>&1
         sed -i -e "/$USERNAME ALL=.*/d" $TARGETDIR/etc/sudoers
-        DIALOG --title "Check $LOG for details" \
-            --infobox "Rebuilding initramfs for target ..." 4 60
+        TITLE="Check $LOG for details ..."
+        INFOBOX "Rebuilding initramfs for target ..." 4 60
         echo "Rebuilding initramfs for target ..." >$LOG
         # mount required fs
         mount_filesystems
         chroot $TARGETDIR dracut --no-hostonly --add-drivers "ahci" --force >>$LOG 2>&1
-        DIALOG --title "Check $LOG for details" \
-            --infobox "Removing temporary packages from target ..." 4 60
+        INFOBOX "Removing temporary packages from target ..." 4 60
         echo "Removing temporary packages from target ..." >$LOG
         xbps-remove -r $TARGETDIR -Ry dialog >>$LOG 2>&1
         rmdir $TARGETDIR/mnt/target
@@ -1189,7 +1226,7 @@ ${BOLD}Do you want to continue?${RESET}" 20 80 || return
         install_packages
     fi
 
-    DIALOG --infobox "Applying installer settings..." 4 60
+    INFOBOX "Applying installer settings..." 4 60
 
     # copy target fstab.
     install -Dm644 $TARGET_FSTAB $TARGETDIR/etc/fstab


### PR DESCRIPTION
+ Add INFOBOX() because dialog --infobox is incompatible with --keep-tite on xterm
+ Use clear after INFOBOX() to not leave irritating info on the screen
+ Make the live system copy process use a --progressbox
+ Use a tar pipe to copy from live ISO to target file system